### PR TITLE
feature: use isolated extension api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "Node.js debugger extension",
   "scripts": {
     "build": "node scripts/build.js",
+    "build:extension": "node scripts/build-extension.js",
+    "predev": "npm run build:extension",
     "dev": "node ./node_modules/@lvce-editor/server/bin/server.js --only-extension=packages/extension --test-path=packages/e2e",
+    "pree2e": "npm run build:extension",
     "e2e": "cd packages/e2e && npm run e2e",
+    "pree2e:headless": "npm run build:extension",
     "e2e:headless": "cd packages/e2e && npm run e2e:headless",
     "postinstall": "lerna bootstrap --ci",
     "lint": "eslint . && prettier --check .",

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -3,7 +3,12 @@
   "name": "Debug Node",
   "description": "Debugger for NodeJS",
   "activation": ["onDebug:node-debug"],
-  "browser": "src/debugNodeMain.js",
+  "browser": "dist/debugNodeMain.js",
+  "isolated": true,
+  "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"],
+  "compatibility": {
+    "web": false
+  },
   "commands": [],
   "languages": [],
   "rpc": [
@@ -13,6 +18,12 @@
       "name": "Debug Node Worker",
       "url": "../debug-worker/src/javascriptDebugWorkerMain.js",
       "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"]
+    },
+    {
+      "id": "builtin.debug-node.node",
+      "type": "node",
+      "name": "Debug Node",
+      "url": "../node/src/nodeMain.js"
     }
   ],
   "repository": "https://github.com/lvce-editor/debug-node"

--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "builtin.debug-node",
       "version": "0.0.0-dev",
+      "license": "MIT",
       "devDependencies": {
+        "@lvce-editor/api": "^8.64.0",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0"
       }
@@ -43,7 +45,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -980,6 +981,117 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lvce-editor/api": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.64.0.tgz",
+      "integrity": "sha512-4Kihuc6yi2eUEI1OzhQHSbCYBhQO774zbmdgRxXSnZsIfUZ12PTOK1XAFTHotJD3pVM0fcmURyc2McHgsseAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/rpc-registry": "^9.24.0",
+        "@lvce-editor/virtual-dom-worker": "^10.0.0"
+      }
+    },
+    "node_modules/@lvce-editor/assert": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
+      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
+      "integrity": "sha512-NZokXOACzuRoIpsHVHx+VhNQwM/QcQ4bl3wc8DgDM/+AxAVT2EU8S9cVQQedtJj94N35zmAB2To6Egm8aifOlw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/constants": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
+      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/ipc": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.5.0.tgz",
+      "integrity": "sha512-SgCmkVlkleWGwKgesKMNI3zlcjS9Hg7sHQ7HsayngbODhtLSUpLb/ZXpw0ziCCZHp377YCw/jwiT4MlzLRRTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/json-rpc": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
+      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/rpc": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/json-rpc": "^8.4.0",
+        "@lvce-editor/verror": "^1.7.0"
+      }
+    },
+    "node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.22.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "node_modules/@lvce-editor/verror": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.7.0.tgz",
+      "integrity": "sha512-+LGuAEIC2L7pbvkyAQVWM2Go0dAy+UWEui28g07zNtZsCBhm+gusBK8PNwLJLV5Jay+TyUYuwLIbJdjLLzqEBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-10.2.0.tgz",
+      "integrity": "sha512-URtDWcAFadP7SLOqfepRxomJmNRQDmON8GFKRfsA1dOgcqBnoBR4G5xwo6oDeZvP4pnRAzHR3QB3b8I6nASU+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.14.0"
+      }
+    },
+    "node_modules/@lvce-editor/web-socket-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-2.1.0.tgz",
+      "integrity": "sha512-Yldf6nJ4seaFaysYTkkLkOhuJQxkdyX/u01vk1X0dXi21882wMtQbDmYZoAg9rVGWbdBFDIdAJ99pFCAM8eUQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1676,7 +1788,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4313,6 +4424,28 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "builtin.debug-node",
   "version": "0.0.0-dev",
   "description": "Node.js debugger extension",
-  "main": "src/languageFeaturesCssMain.js",
+  "main": "dist/debugNodeMain.js",
   "scripts": {
     "test": "node --unhandled-rejections=warn --experimental-vm-modules ./node_modules/jest/bin/jest.js --detectOpenHandles --forceExit",
     "test:watch": "node --unhandled-rejections=warn --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch"
@@ -14,6 +14,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
+    "@lvce-editor/api": "^8.64.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0"
   },

--- a/packages/extension/src/debugNodeMain.js
+++ b/packages/extension/src/debugNodeMain.js
@@ -1,8 +1,22 @@
+import {
+  activate as activateExtensionApi,
+  registerDebugProvider,
+} from '@lvce-editor/api'
 import * as DebugProvider from './parts/DebugProvider/DebugProvider.js'
-import * as PathState from './parts/PathState/PathState.js'
 
-export const activate = ({ path }) => {
-  PathState.state.path = path
-  // @ts-ignore
-  vscode.registerDebugProvider(DebugProvider)
+const state = {
+  isActivated: false,
 }
+
+export const activate = async () => {
+  if (state.isActivated) {
+    return
+  }
+  state.isActivated = true
+  await activateExtensionApi()
+  registerDebugProvider(DebugProvider)
+}
+
+export const deactivate = () => {}
+
+await activate()

--- a/packages/extension/src/parts/DebugNodeUrl/DebugNodeUrl.js
+++ b/packages/extension/src/parts/DebugNodeUrl/DebugNodeUrl.js
@@ -1,6 +1,0 @@
-import * as PathState from '../PathState/PathState.js'
-
-export const getDebugNodeUrl = () => {
-  const nodePath = PathState.state.path + '/../node/src/nodeMain.js'
-  return nodePath
-}

--- a/packages/extension/src/parts/DebugWorker/DebugWorker.js
+++ b/packages/extension/src/parts/DebugWorker/DebugWorker.js
@@ -1,15 +1,29 @@
+import { createRpc } from '@lvce-editor/api'
+import * as DebugWorkerUrl from '../DebugWorkerUrl/DebugWorkerUrl.js'
 import * as Execute from '../Execute/Execute.js'
 
-// @ts-ignore
-const rpc = vscode.createRpc({
-  id: 'builtin.debug-node.debug-worker',
-  execute: Execute.execute,
-})
+/**
+ * @typedef {{
+ *   invoke(method: string, ...params: readonly unknown[]): Promise<any>
+ * }} Rpc
+ */
 
-export const getInstance = async () => {
-  return rpc
+/** @type {{ rpcPromise: Promise<Rpc> | undefined }} */
+const state = {
+  rpcPromise: undefined,
 }
 
-export const invoke = (method, ...params) => {
+/** @returns {Promise<Rpc>} */
+export const getInstance = () => {
+  state.rpcPromise ||= createRpc({
+    commandMap: Execute.commandMap,
+    name: 'Debug Node Worker',
+    url: DebugWorkerUrl.getDebugWorkerUrl(),
+  })
+  return state.rpcPromise
+}
+
+export const invoke = async (method, ...params) => {
+  const rpc = await getInstance()
   return rpc.invoke(method, ...params)
 }

--- a/packages/extension/src/parts/DebugWorkerUrl/DebugWorkerUrl.js
+++ b/packages/extension/src/parts/DebugWorkerUrl/DebugWorkerUrl.js
@@ -1,6 +1,6 @@
 export const getDebugWorkerUrl = () => {
   return new URL(
-    '../../../../debug-worker/src/javascriptDebugWorkerMain.js',
+    '../../debug-worker/src/javascriptDebugWorkerMain.js',
     import.meta.url,
   ).toString()
 }

--- a/packages/extension/src/parts/Execute/Execute.js
+++ b/packages/extension/src/parts/Execute/Execute.js
@@ -1,19 +1,30 @@
 import * as EmitterState from '../EmitterState/EmitterState.js'
 import * as GetJson from '../GetJson/GetJson.js'
 
-export const execute = async (method, ...params) => {
+const handleScriptPaused = (...params) => {
   const emitter = EmitterState.get()
-  if (method === 'Ajax.getJson') {
-    return GetJson.getJson(...params)
-  } else if (method === 'Debug.handleScriptPaused') {
-    emitter.handlePaused(...params)
-  } else if (method === 'Debug.handleScriptParsed') {
-    emitter.handleScriptParsed(...params)
-  } else if (method === 'Debug.handleResumed') {
-    emitter.handleResumed(...params)
-  } else if (method === 'Debug.handleChange') {
-    emitter.handleChange(...params)
-  } else {
-    console.log({ method })
-  }
+  return emitter.handlePaused(...params)
+}
+
+const handleScriptParsed = (...params) => {
+  const emitter = EmitterState.get()
+  return emitter.handleScriptParsed(...params)
+}
+
+const handleResumed = (...params) => {
+  const emitter = EmitterState.get()
+  return emitter.handleResumed(...params)
+}
+
+const handleChange = (...params) => {
+  const emitter = EmitterState.get()
+  return emitter.handleChange(...params)
+}
+
+export const commandMap = {
+  'Ajax.getJson': GetJson.getJson,
+  'Debug.handleChange': handleChange,
+  'Debug.handleResumed': handleResumed,
+  'Debug.handleScriptParsed': handleScriptParsed,
+  'Debug.handleScriptPaused': handleScriptPaused,
 }

--- a/packages/extension/src/parts/GetJson/GetJson.js
+++ b/packages/extension/src/parts/GetJson/GetJson.js
@@ -1,26 +1,12 @@
-import * as DebugNodeUrl from '../DebugNodeUrl/DebugNodeUrl.js'
-
-// const getJsonLocal = async (url) => {
-//   const response = await fetch(url)
-//   if (!response.ok) {
-//     throw new Error(response.statusText)
-//   }
-//   const json = await response.json()
-//   return json
-// }
+import { createNodeRpc } from '@lvce-editor/api'
 
 export const getJson = async (url) => {
-  // if (url && url.startsWith('http://localhost')) {
-  //   return getJsonLocal(url)
-  // }
-
-  const nodePath = DebugNodeUrl.getDebugNodeUrl()
-  // @ts-ignore
-  const nodeRpc = await vscode.createNodeRpc({
-    path: nodePath,
-    name: 'Debug Worker',
+  const nodeRpc = await createNodeRpc({
+    id: 'builtin.debug-node.node',
   })
-  const json = await nodeRpc.invoke('Ajax.getJson', url)
-  await nodeRpc.dispose()
-  return json
+  try {
+    return await nodeRpc.invoke('Ajax.getJson', url)
+  } finally {
+    await nodeRpc.dispose()
+  }
 }

--- a/packages/extension/src/parts/PathState/PathState.js
+++ b/packages/extension/src/parts/PathState/PathState.js
@@ -1,3 +1,0 @@
-export const state = {
-  path: '',
-}

--- a/packages/extension/test/Execute.test.js
+++ b/packages/extension/test/Execute.test.js
@@ -1,0 +1,32 @@
+import * as EmitterState from '../src/parts/EmitterState/EmitterState.js'
+import { commandMap } from '../src/parts/Execute/Execute.js'
+
+test('forwards debug worker events to the provider emitter', async () => {
+  const invocations = []
+  EmitterState.set({
+    handleChange(...args) {
+      invocations.push(['change', ...args])
+    },
+    handlePaused(...args) {
+      invocations.push(['paused', ...args])
+    },
+    handleResumed(...args) {
+      invocations.push(['resumed', ...args])
+    },
+    handleScriptParsed(...args) {
+      invocations.push(['script-parsed', ...args])
+    },
+  })
+
+  await commandMap['Debug.handleChange']({ type: 'paused' })
+  await commandMap['Debug.handleScriptPaused']({ reason: 'breakpoint' })
+  await commandMap['Debug.handleResumed']()
+  await commandMap['Debug.handleScriptParsed']({ scriptId: '1' })
+
+  expect(invocations).toEqual([
+    ['change', { type: 'paused' }],
+    ['paused', { reason: 'breakpoint' }],
+    ['resumed'],
+    ['script-parsed', { scriptId: '1' }],
+  ])
+})

--- a/packages/extension/test/debugNodeMain.test.js
+++ b/packages/extension/test/debugNodeMain.test.js
@@ -1,1 +1,28 @@
-test('', () => {})
+import { readFileSync } from 'node:fs'
+
+const manifestUrl = new URL('../extension.json', import.meta.url)
+const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'))
+
+test('uses the isolated extension api', () => {
+  expect(manifest.browser).toBe('dist/debugNodeMain.js')
+  expect(manifest.isolated).toBe(true)
+})
+
+test('declares the debug web worker rpc', () => {
+  expect(manifest.rpc).toContainEqual({
+    contentSecurityPolicy: ["default-src 'none'", "script-src 'self'"],
+    id: 'builtin.debug-node.debug-worker',
+    name: 'Debug Node Worker',
+    type: 'web-worker',
+    url: '../debug-worker/src/javascriptDebugWorkerMain.js',
+  })
+})
+
+test('declares the debug node rpc', () => {
+  expect(manifest.rpc).toContainEqual({
+    id: 'builtin.debug-node.node',
+    name: 'Debug Node',
+    type: 'node',
+    url: '../node/src/nodeMain.js',
+  })
+})

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -1,0 +1,16 @@
+import { bundleJs } from '@lvce-editor/package-extension'
+import { mkdir, rm } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const extension = join(root, 'packages', 'extension')
+const outDir = join(extension, 'dist')
+
+await rm(outDir, { force: true, recursive: true })
+await mkdir(outDir, { recursive: true })
+await bundleJs(
+  join(extension, 'src', 'debugNodeMain.js'),
+  join(outDir, 'debugNodeMain.js'),
+  false,
+)

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = path.join(__dirname, '..')
 
+await import('./build-extension.js')
+
 await exportStatic({
   extensionPath: 'packages/extension',
   root,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,4 @@
-import { packageExtension } from '@lvce-editor/package-extension'
+import { bundleJs, packageExtension } from '@lvce-editor/package-extension'
 import { execSync } from 'child_process'
 import fs, { cpSync, readFileSync, writeFileSync } from 'fs'
 import path, { dirname, join } from 'path'
@@ -93,26 +93,26 @@ const replace = ({ path, occurrence, replacement }) => {
 }
 
 replace({
-  path: join(
-    root,
-    'dist',
-    'src',
-    'parts',
-    'DebugWorkerUrl',
-    'DebugWorkerUrl.js',
-  ),
-  occurrence: '../debug-worker/',
-  replacement: 'debug-worker/',
-})
-replace({
-  path: join(root, 'dist', 'src', 'parts', 'DebugNodeUrl', 'DebugNodeUrl.js'),
-  occurrence: '../node/',
-  replacement: 'node/',
-})
-replace({
   path: join(root, 'dist', 'extension.json'),
   occurrence: '../debug-worker/',
   replacement: 'debug-worker/',
+})
+replace({
+  path: join(root, 'dist', 'extension.json'),
+  occurrence: '../node/',
+  replacement: 'node/',
+})
+
+await bundleJs(
+  join(extension, 'src', 'debugNodeMain.js'),
+  join(root, 'dist', 'dist', 'debugNodeMain.js'),
+  false,
+)
+
+replace({
+  path: join(root, 'dist', 'dist', 'debugNodeMain.js'),
+  occurrence: '../../debug-worker/',
+  replacement: '../debug-worker/',
 })
 
 await packageExtension({


### PR DESCRIPTION
Summary:
- run the Node debugger entry point as an isolated extension
- register the debug provider through the isolated extension API
- use isolated web-worker and manifest-scoped Node RPCs