### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2488,12 +2488,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.64.0.tgz",
-      "integrity": "sha512-4Kihuc6yi2eUEI1OzhQHSbCYBhQO774zbmdgRxXSnZsIfUZ12PTOK1XAFTHotJD3pVM0fcmURyc2McHgsseAag==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -15023,7 +15024,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/api": "^8.64.0",
+        "@lvce-editor/api": "^8.75.0",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/api": "^8.64.0",
+    "@lvce-editor/api": "^8.75.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0"
   },


### PR DESCRIPTION
Update the extension API to 8.75.0 so unused extension commands can be removed from the production bundle. This removes about 39 KB from the extension worker bundle without changing behavior.