### PR TITLE
fix: preserve packaged extension readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pree2e:headless": "npm run build:extension",
     "e2e:headless": "cd packages/e2e && npm run e2e:headless",
     "lint": "eslint . && prettier --check . && knip --no-config-hints",
-    "test": "npm test --workspaces --if-present",
+    "test": "npm test --workspaces --if-present && npm run test:build",
+    "test:build": "node --test scripts/*.test.js",
     "test:watch": "node --unhandled-rejections=warn --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
     "type-check": "tsc -b"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,10 +1,7 @@
 import { bundleJs, packageExtension } from '@lvce-editor/package-extension'
-import { execSync } from 'child_process'
 import fs, { cpSync, readFileSync, writeFileSync } from 'fs'
 import path, { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
-
-const NOT_NEEDED = []
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = path.join(__dirname, '..')
@@ -38,38 +35,6 @@ fs.copyFileSync(
 fs.cpSync(join(extension, 'src'), join(root, 'dist', 'src'), {
   recursive: true,
 })
-
-const getAllDependencies = (obj) => {
-  if (!obj || !obj.dependencies) {
-    return []
-  }
-  return [obj, ...Object.values(obj.dependencies).flatMap(getAllDependencies)]
-}
-
-const getDependencies = (cwd) => {
-  const stdout = execSync('npm list --omit=dev --parseable --all', {
-    cwd,
-  }).toString()
-  const lines = stdout.split('\n')
-  return lines.slice(1, -1)
-}
-
-const copyDependencies = (from, to) => {
-  const dependencies = getDependencies(from)
-  for (const dependency of dependencies) {
-    fs.cpSync(dependency, join(dist, to, dependency.slice(from.length)), {
-      recursive: true,
-    })
-  }
-}
-
-copyDependencies(extension, '')
-
-copyDependencies(node, 'node')
-
-for (const notNeeded of NOT_NEEDED) {
-  fs.rmSync(join(dist, 'node', notNeeded), { force: true, recursive: true })
-}
 
 cpSync(join(root, 'packages', 'node', 'src'), join(dist, 'node', 'src'), {
   recursive: true,

--- a/scripts/build.test.js
+++ b/scripts/build.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('packages the extension README', async () => {
+  await import('./build.js')
+
+  const sourceReadme = await readFile(join(root, 'README.md'), 'utf8')
+  const packagedReadme = await readFile(join(root, 'dist', 'README.md'), 'utf8')
+
+  assert.equal(packagedReadme, sourceReadme)
+})


### PR DESCRIPTION
Fix the release build after the npm-workspaces migration so hoisted development dependencies no longer overwrite top-level extension files. Add a regression test that verifies the packaged README matches the Debug Node README.