### PR TITLE
fix: avoid nested debug startup rpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14984,6 +14984,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
+        "@jest/globals": "30.2.0",
         "@lvce-editor/api": "^8.75.0",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0"

--- a/packages/debug-worker/src/parts/DebugProvider/DebugProvider.js
+++ b/packages/debug-worker/src/parts/DebugProvider/DebugProvider.js
@@ -1,7 +1,6 @@
 import * as DevtoolsCommandType from '../DevtoolsCommandType/DevtoolsCommandType.js'
 import * as DevtoolsProtocolDebugger from '../DevtoolsProtocolDebugger/DevtoolsProtocolDebugger.js'
 import * as DevtoolsProtocolRuntime from '../DevtoolsProtocolRuntime/DevtoolsProtocolRuntime.js'
-import { getWebSocketDebuggerUrl } from '../GetWebSocketDebuggerUrl/GetWebSocketDebuggerUrl.js'
 import * as Ipc from '../Ipc/Ipc.js'
 import * as PauseOnExceptionState from '../PauseOnExceptionState/PauseOnExceptionState.js'
 import * as UnwrapDevtoolsEvaluateResult from '../UnwrapDevtoolsEvaluateResult/UnwrapDevtoolsEvaluateResult.js'
@@ -99,18 +98,7 @@ export const getScripts = () => {
 
 let oldEmitterEnabled = false // old push based emitter
 
-export const start = async (emitter) => {
-  // try {
-  //   const jsonList = await getJsonList()
-  // } catch (error) {
-  //   console.log({ error })
-  //   if (error && error.code === ErrorCodes.ECONNREFUSED) {
-  //     // TODO no debugged process is available
-  //     console.log('conn resufsed')
-  //   }
-  //   return
-  // }
-  const { webSocketDebuggerUrl, isAvailable } = await getWebSocketDebuggerUrl()
+export const start = async (emitter, webSocketDebuggerUrl, isAvailable) => {
   state.isAvailable = isAvailable
   if (!isAvailable) {
     return

--- a/packages/debug-worker/src/parts/DebugStart/DebugStart.js
+++ b/packages/debug-worker/src/parts/DebugStart/DebugStart.js
@@ -1,6 +1,6 @@
 import * as DebugProvider from '../DebugProvider/DebugProvider.js'
 
-export const debugStart = async () => {
+export const debugStart = async (webSocketDebuggerUrl, isAvailable) => {
   const emitter = {
     handleScriptParsed(args) {
       // @ts-ignore
@@ -19,5 +19,5 @@ export const debugStart = async () => {
       rpc.invoke('Debug.handleChange', params)
     },
   }
-  await DebugProvider.start(emitter)
+  await DebugProvider.start(emitter, webSocketDebuggerUrl, isAvailable)
 }

--- a/packages/debug-worker/src/parts/GetJson/GetJson.js
+++ b/packages/debug-worker/src/parts/GetJson/GetJson.js
@@ -1,4 +1,0 @@
-export const getJson = async (url) => {
-  // @ts-ignore
-  return rpc.invoke('Ajax.getJson', url)
-}

--- a/packages/debug-worker/test/DebugStart.test.js
+++ b/packages/debug-worker/test/DebugStart.test.js
@@ -1,0 +1,28 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const start = jest.fn()
+
+jest.unstable_mockModule('../src/parts/DebugProvider/DebugProvider.js', () => ({
+  start,
+}))
+
+const { debugStart } = await import('../src/parts/DebugStart/DebugStart.js')
+
+beforeEach(() => {
+  start.mockReset()
+})
+
+test('starts the provider with the resolved debugger endpoint', async () => {
+  await debugStart('ws://localhost:9229/debugger', true)
+
+  expect(start).toHaveBeenCalledWith(
+    expect.objectContaining({
+      handleChange: expect.any(Function),
+      handlePaused: expect.any(Function),
+      handleResumed: expect.any(Function),
+      handleScriptParsed: expect.any(Function),
+    }),
+    'ws://localhost:9229/debugger',
+    true,
+  )
+})

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
+    "@jest/globals": "30.2.0",
     "@lvce-editor/api": "^8.75.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0"

--- a/packages/extension/src/parts/DebugProvider/DebugProvider.js
+++ b/packages/extension/src/parts/DebugProvider/DebugProvider.js
@@ -1,12 +1,14 @@
 import * as DebugWorker from '../DebugWorker/DebugWorker.js'
 import * as EmitterState from '../EmitterState/EmitterState.js'
+import { getWebSocketDebuggerUrl } from '../GetWebSocketDebuggerUrl/GetWebSocketDebuggerUrl.js'
 
 export const id = 'node-debug'
 
 export const start = async (emitter) => {
   EmitterState.set(emitter)
+  const { webSocketDebuggerUrl, isAvailable } = await getWebSocketDebuggerUrl()
   const rpc = await DebugWorker.getInstance()
-  await rpc.invoke('Debug.start')
+  await rpc.invoke('Debug.start', webSocketDebuggerUrl, isAvailable)
 }
 
 export const listProcesses = async () => {

--- a/packages/extension/src/parts/Execute/Execute.js
+++ b/packages/extension/src/parts/Execute/Execute.js
@@ -1,5 +1,4 @@
 import * as EmitterState from '../EmitterState/EmitterState.js'
-import * as GetJson from '../GetJson/GetJson.js'
 
 const handleScriptPaused = (...params) => {
   const emitter = EmitterState.get()
@@ -22,7 +21,6 @@ const handleChange = (...params) => {
 }
 
 export const commandMap = {
-  'Ajax.getJson': GetJson.getJson,
   'Debug.handleChange': handleChange,
   'Debug.handleResumed': handleResumed,
   'Debug.handleScriptParsed': handleScriptParsed,

--- a/packages/extension/src/parts/GetWebSocketDebuggerUrl/GetWebSocketDebuggerUrl.js
+++ b/packages/extension/src/parts/GetWebSocketDebuggerUrl/GetWebSocketDebuggerUrl.js
@@ -6,7 +6,7 @@ export const getWebSocketDebuggerUrl = async () => {
     const process = json[0]
     const { webSocketDebuggerUrl } = process
     return { json, webSocketDebuggerUrl, isAvailable: true }
-  } catch (error) {
+  } catch {
     return {
       json: {},
       webSocketDebuggerUrl: '',

--- a/packages/extension/test/DebugProvider.test.js
+++ b/packages/extension/test/DebugProvider.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const getJson = jest.fn()
+const getInstance = jest.fn()
+const invoke = jest.fn()
+
+jest.unstable_mockModule('../src/parts/GetJson/GetJson.js', () => ({
+  getJson,
+}))
+
+jest.unstable_mockModule('../src/parts/DebugWorker/DebugWorker.js', () => ({
+  getInstance,
+}))
+
+const DebugProvider =
+  await import('../src/parts/DebugProvider/DebugProvider.js')
+
+beforeEach(() => {
+  getJson.mockReset()
+  getInstance.mockReset()
+  invoke.mockReset()
+  getInstance.mockResolvedValue({ invoke })
+})
+
+test('resolves the debugger endpoint before starting the debug worker', async () => {
+  const calls = []
+  getJson.mockImplementation(async () => {
+    calls.push('get-json')
+    return [{ webSocketDebuggerUrl: 'ws://localhost:9229/debugger' }]
+  })
+  getInstance.mockImplementation(async () => {
+    calls.push('get-debug-worker')
+    return { invoke }
+  })
+
+  await DebugProvider.start({})
+
+  expect(calls).toEqual(['get-json', 'get-debug-worker'])
+  expect(invoke).toHaveBeenCalledWith(
+    'Debug.start',
+    'ws://localhost:9229/debugger',
+    true,
+  )
+})
+
+test('starts the debug worker as unavailable when endpoint discovery fails', async () => {
+  getJson.mockRejectedValue(new Error('connection refused'))
+
+  await DebugProvider.start({})
+
+  expect(invoke).toHaveBeenCalledWith('Debug.start', '', false)
+})


### PR DESCRIPTION
Moves debugger endpoint discovery into the isolated extension before starting the debug web worker. This prevents Run and Debug startup from blocking later editor UI events while preserving unavailable and connected debugger behavior.