### PR TITLE
fix: expose debug status rpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,9 +2458,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.75.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
-      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
+      "version": "8.83.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.83.2.tgz",
+      "integrity": "sha512-D5oS8rC99qiYg+5ZdHd5gzhwxNp7iysDjmmUiDH+3ZSqZ2jgHet45Eh59UrmNbaO27rtKulzcgxlQFjdZfFR8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14985,7 +14985,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "30.2.0",
-        "@lvce-editor/api": "^8.75.0",
+        "@lvce-editor/api": "^8.83.2",
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "@jest/globals": "30.2.0",
-    "@lvce-editor/api": "^8.75.0",
+    "@lvce-editor/api": "^8.83.2",
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0"
   },


### PR DESCRIPTION
## Summary

- bundle the corrected extension API debug command map
- allow Run and Debug status loading to complete so later activity-bar switches remain responsive