### PR TITLE
fix: start debug worker rpc listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2529,14 +2529,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.5.1.tgz",
       "integrity": "sha512-euS3PuVVjZy06bPFbgTz1yjQ0mY5BgWeYEDb9eQL2ncqYeap0ADy1D57nddlps1VkhHxj1g2ifXkLeIKLkQYJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
       "integrity": "sha512-NZokXOACzuRoIpsHVHx+VhNQwM/QcQ4bl3wc8DgDM/+AxAVT2EU8S9cVQQedtJj94N35zmAB2To6Egm8aifOlw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
@@ -4247,7 +4245,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.7.0.tgz",
       "integrity": "sha512-+LGuAEIC2L7pbvkyAQVWM2Go0dAy+UWEui28g07zNtZsCBhm+gusBK8PNwLJLV5Jay+TyUYuwLIbJdjLLzqEBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom-worker": {
@@ -4271,7 +4268,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-2.1.0.tgz",
       "integrity": "sha512-Yldf6nJ4seaFaysYTkkLkOhuJQxkdyX/u01vk1X0dXi21882wMtQbDmYZoAg9rVGWbdBFDIdAJ99pFCAM8eUQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.2"
@@ -14733,10 +14729,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14955,10 +14950,47 @@
       "name": "javascript-debug-worker",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/rpc": "^6.16.0"
+      },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0"
+      }
+    },
+    "packages/debug-worker/node_modules/@lvce-editor/ipc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/debug-worker/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
+      "license": "MIT"
+    },
+    "packages/debug-worker/node_modules/@lvce-editor/rpc": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/ipc": "^16.9.0",
+        "@lvce-editor/json-rpc": "^8.4.0",
+        "@lvce-editor/verror": "^1.7.0"
       }
     },
     "packages/debug-worker/node_modules/@types/jest": {

--- a/packages/debug-worker/package.json
+++ b/packages/debug-worker/package.json
@@ -17,5 +17,8 @@
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "@lvce-editor/rpc": "^6.16.0"
   }
 }

--- a/packages/debug-worker/src/javascriptDebugWorkerMain.js
+++ b/packages/debug-worker/src/javascriptDebugWorkerMain.js
@@ -1,1 +1,6 @@
-export * from './parts/Main/Main.js'
+import { WebWorkerRpcClient } from '@lvce-editor/rpc'
+import { commandMap } from './parts/Main/Main.js'
+
+export { commandMap } from './parts/Main/Main.js'
+
+globalThis.rpc = await WebWorkerRpcClient.create({ commandMap })

--- a/packages/debug-worker/test/JavascriptDebugWorkerMain.test.js
+++ b/packages/debug-worker/test/JavascriptDebugWorkerMain.test.js
@@ -1,0 +1,24 @@
+import { afterAll, expect, jest, test } from '@jest/globals'
+
+const rpc = {
+  invoke: jest.fn(),
+}
+const create = jest.fn(async () => rpc)
+
+jest.unstable_mockModule('@lvce-editor/rpc', () => ({
+  WebWorkerRpcClient: { create },
+}))
+
+const { commandMap } = await import('../src/javascriptDebugWorkerMain.js')
+
+afterAll(() => {
+  // @ts-ignore
+  delete globalThis.rpc
+})
+
+test('starts a web worker rpc client with the debug command map', () => {
+  expect(create).toHaveBeenCalledTimes(1)
+  expect(create).toHaveBeenCalledWith({ commandMap })
+  // @ts-ignore
+  expect(globalThis.rpc).toBe(rpc)
+})

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,9 +4,8 @@
   "description": "End-to-end tests for the Node.js debugger",
   "main": "index.js",
   "scripts": {
-    "#e2e:headless": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=../extension --test-path=. --headless",
     "e2e": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=../extension --test-path=.",
-    "e2e:headless": "echo ok"
+    "e2e:headless": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=../extension --test-path=. --headless"
   },
   "type": "module",
   "author": {

--- a/packages/e2e/src/debug-node.js
+++ b/packages/e2e/src/debug-node.js
@@ -1,3 +1,14 @@
-test('debug-node', async () => {
-  //  TODO
-})
+export const name = 'debug-node.run-and-debug-does-not-block-sidebar'
+
+export const test = async ({ expect, Locator, SideBar }) => {
+  await SideBar.open('Run And Debug')
+  await expect(
+    Locator('.ActivityBarItem[title="Run and Debug"]'),
+  ).toHaveAttribute('aria-selected', 'true')
+
+  await SideBar.open('Search')
+  await expect(Locator('.ActivityBarItem[title="Search"]')).toHaveAttribute(
+    'aria-selected',
+    'true',
+  )
+}

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -16,7 +16,7 @@
       "id": "builtin.debug-node.debug-worker",
       "type": "web-worker",
       "name": "Debug Node Worker",
-      "url": "../debug-worker/src/javascriptDebugWorkerMain.js",
+      "url": "../debug-worker/dist/javascriptDebugWorkerMain.js",
       "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"]
     },
     {

--- a/packages/extension/src/parts/DebugWorkerUrl/DebugWorkerUrl.js
+++ b/packages/extension/src/parts/DebugWorkerUrl/DebugWorkerUrl.js
@@ -1,6 +1,6 @@
 export const getDebugWorkerUrl = () => {
   return new URL(
-    '../../debug-worker/src/javascriptDebugWorkerMain.js',
+    '../../debug-worker/dist/javascriptDebugWorkerMain.js',
     import.meta.url,
   ).toString()
 }

--- a/packages/extension/test/debugNodeMain.test.js
+++ b/packages/extension/test/debugNodeMain.test.js
@@ -14,7 +14,7 @@ test('declares the debug web worker rpc', () => {
     id: 'builtin.debug-node.debug-worker',
     name: 'Debug Node Worker',
     type: 'web-worker',
-    url: '../debug-worker/src/javascriptDebugWorkerMain.js',
+    url: '../debug-worker/dist/javascriptDebugWorkerMain.js',
   })
 })
 

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -5,12 +5,27 @@ import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const extension = join(root, 'packages', 'extension')
-const outDir = join(extension, 'dist')
+const extensionOutDir = join(extension, 'dist')
+const debugWorker = join(root, 'packages', 'debug-worker')
+const debugWorkerOutDir = join(debugWorker, 'dist')
 
-await rm(outDir, { force: true, recursive: true })
-await mkdir(outDir, { recursive: true })
-await bundleJs(
-  join(extension, 'src', 'debugNodeMain.js'),
-  join(outDir, 'debugNodeMain.js'),
-  false,
-)
+await Promise.all([
+  rm(extensionOutDir, { force: true, recursive: true }),
+  rm(debugWorkerOutDir, { force: true, recursive: true }),
+])
+await Promise.all([
+  mkdir(extensionOutDir, { recursive: true }),
+  mkdir(debugWorkerOutDir, { recursive: true }),
+])
+await Promise.all([
+  bundleJs(
+    join(extension, 'src', 'debugNodeMain.js'),
+    join(extensionOutDir, 'debugNodeMain.js'),
+    false,
+  ),
+  bundleJs(
+    join(debugWorker, 'src', 'javascriptDebugWorkerMain.js'),
+    join(debugWorkerOutDir, 'javascriptDebugWorkerMain.js'),
+    false,
+  ),
+])

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -44,9 +44,7 @@ cpSync(
   join(dist, 'node', 'package.json'),
 )
 
-fs.cpSync(join(debugWorker, 'src'), join(root, 'dist', 'debug-worker', 'src'), {
-  recursive: true,
-})
+fs.mkdirSync(join(root, 'dist', 'debug-worker', 'dist'), { recursive: true })
 
 const replace = ({ path, occurrence, replacement }) => {
   const oldContent = readFileSync(path, 'utf-8')
@@ -71,6 +69,12 @@ replace({
 await bundleJs(
   join(extension, 'src', 'debugNodeMain.js'),
   join(root, 'dist', 'dist', 'debugNodeMain.js'),
+  false,
+)
+
+await bundleJs(
+  join(debugWorker, 'src', 'javascriptDebugWorkerMain.js'),
+  join(root, 'dist', 'debug-worker', 'dist', 'javascriptDebugWorkerMain.js'),
   false,
 )
 

--- a/scripts/build.test.js
+++ b/scripts/build.test.js
@@ -14,3 +14,16 @@ test('packages the extension README', async () => {
 
   assert.equal(packagedReadme, sourceReadme)
 })
+
+test('packages a listening debug worker', async () => {
+  await import('./build.js')
+
+  const worker = await readFile(
+    join(root, 'dist', 'debug-worker', 'dist', 'javascriptDebugWorkerMain.js'),
+    'utf8',
+  )
+
+  assert.match(worker, /Debug\.getStatus/)
+  assert.match(worker, /globalThis\.rpc/)
+  assert.doesNotMatch(worker, /from ['"]@lvce-editor\/rpc['"]/)
+})


### PR DESCRIPTION
## Summary
- start the Debug Node web worker RPC client before accepting provider commands
- bundle the worker and point the extension manifest at the built entry
- cover the Run and Debug to Search transition end to end