### PR TITLE
feature: self-host debug node rpc process

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -25,7 +25,7 @@
       "ignoreDependencies": ["jest"]
     },
     "packages/node": {
-      "entry": ["src/nodeMain.js"],
+      "entry": ["src/nodeProcess.js"],
       "project": ["src/**/*.js"]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.4.0",
         "@lvce-editor/package-extension": "^3.2.0",
+        "@lvce-editor/rpc": "^6.19.1",
         "@lvce-editor/server": "0.103.19",
         "@lvce-editor/shared-process": "^0.103.19",
         "@types/node": "^25.0.9",
@@ -2684,6 +2685,7 @@
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.11.0.tgz",
       "integrity": "sha512-+P1E4Oi1RF/UoJQba2v4Q3E/s6L6ubJOJ2u8jASG/KSijBf12OWKnIxwJBKQtyKXVnay5kE4HNMciqaNVrJZmg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -2699,6 +2701,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
       "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -3312,15 +3315,15 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.18.0.tgz",
-      "integrity": "sha512-c4AYWipYe3l0LGFJqqQQbToyspN09WaR7GieFuhDD0CDfGVZLbjMffJxxpUqoRbDIc0Brd4eXBJha0/6/4jAUw==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.19.1.tgz",
+      "integrity": "sha512-3DwH6ofT2/pBEY28QjdoaALf8MylKrHDxA2hUSx5+OCHurZUhBYiBKLbvI8fx1VXaCkWElzf5g6qBGgwHWDSVA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.11.0",
-        "@lvce-editor/json-rpc": "^8.6.0",
+        "@lvce-editor/ipc": "^16.12.0",
+        "@lvce-editor/json-rpc": "^8.7.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
@@ -3335,6 +3338,27 @@
         "@lvce-editor/constants": "^5.27.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
+    },
+    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/ipc": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.12.0.tgz",
+      "integrity": "sha512-HIvnQXJafvzMxvT5wzr+14IT4hzD1RhjpgmtWni4NrR5QbVvzH+SfgwudjKZW5iNXY2jjWQb1ZU6Hqu4BR3f/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.7.0.tgz",
+      "integrity": "sha512-31bqdXnEKSXDYWcULk0IeBP2jXXfb64R5ScfmiJolhs5r/SPdeKqu8CfqESHpOuyrN1Gq61sgG/2HCwnkAgfIA==",
+      "license": "MIT"
     },
     "node_modules/@lvce-editor/search-process": {
       "version": "15.8.0",
@@ -17829,6 +17853,9 @@
       "name": "debug-worker-node",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@lvce-editor/rpc": "^6.19.1"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.4.0",
     "@lvce-editor/package-extension": "^3.2.0",
+    "@lvce-editor/rpc": "^6.19.1",
     "@lvce-editor/server": "0.103.19",
     "@lvce-editor/shared-process": "^0.103.19",
     "@types/node": "^25.0.9",

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -21,9 +21,9 @@
     },
     {
       "id": "builtin.debug-node.node",
-      "type": "node",
+      "type": "node-process",
       "name": "Debug Node",
-      "url": "../node/src/nodeMain.js"
+      "url": "dist/nodeProcess.js"
     }
   ],
   "repository": "https://github.com/lvce-editor/debug-node"

--- a/packages/extension/test/debugNodeMain.test.js
+++ b/packages/extension/test/debugNodeMain.test.js
@@ -22,7 +22,7 @@ test('declares the debug node rpc', () => {
   expect(manifest.rpc).toContainEqual({
     id: 'builtin.debug-node.node',
     name: 'Debug Node',
-    type: 'node',
-    url: '../node/src/nodeMain.js',
+    type: 'node-process',
+    url: 'dist/nodeProcess.js',
   })
 })

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "@lvce-editor/rpc": "^6.19.1"
   }
 }

--- a/packages/node/src/nodeMain.js
+++ b/packages/node/src/nodeMain.js
@@ -1,1 +1,0 @@
-export * from './parts/Main/Main.js'

--- a/packages/node/src/nodeProcess.js
+++ b/packages/node/src/nodeProcess.js
@@ -1,0 +1,4 @@
+import { NodeRpcProcess } from '@lvce-editor/rpc'
+import { commandMap } from './parts/Main/Main.js'
+
+await NodeRpcProcess.create({ commandMap })

--- a/scripts/build-extension.js
+++ b/scripts/build-extension.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const extension = join(root, 'packages', 'extension')
 const extensionOutDir = join(extension, 'dist')
+const node = join(root, 'packages', 'node')
 const debugWorker = join(root, 'packages', 'debug-worker')
 const debugWorkerOutDir = join(debugWorker, 'dist')
 
@@ -26,6 +27,11 @@ await Promise.all([
   bundleJs(
     join(debugWorker, 'src', 'javascriptDebugWorkerMain.js'),
     join(debugWorkerOutDir, 'javascriptDebugWorkerMain.js'),
+    false,
+  ),
+  bundleJs(
+    join(node, 'src', 'nodeProcess.js'),
+    join(extensionOutDir, 'nodeProcess.js'),
     false,
   ),
 ])

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 import { bundleJs, packageExtension } from '@lvce-editor/package-extension'
-import fs, { cpSync, readFileSync, writeFileSync } from 'fs'
+import fs, { readFileSync, writeFileSync } from 'fs'
 import path, { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -36,14 +36,6 @@ fs.cpSync(join(extension, 'src'), join(root, 'dist', 'src'), {
   recursive: true,
 })
 
-cpSync(join(root, 'packages', 'node', 'src'), join(dist, 'node', 'src'), {
-  recursive: true,
-})
-cpSync(
-  join(root, 'packages', 'node', 'package.json'),
-  join(dist, 'node', 'package.json'),
-)
-
 fs.mkdirSync(join(root, 'dist', 'debug-worker', 'dist'), { recursive: true })
 
 const replace = ({ path, occurrence, replacement }) => {
@@ -60,12 +52,6 @@ replace({
   occurrence: '../debug-worker/',
   replacement: 'debug-worker/',
 })
-replace({
-  path: join(root, 'dist', 'extension.json'),
-  occurrence: '../node/',
-  replacement: 'node/',
-})
-
 await bundleJs(
   join(extension, 'src', 'debugNodeMain.js'),
   join(root, 'dist', 'dist', 'debugNodeMain.js'),
@@ -75,6 +61,12 @@ await bundleJs(
 await bundleJs(
   join(debugWorker, 'src', 'javascriptDebugWorkerMain.js'),
   join(root, 'dist', 'debug-worker', 'dist', 'javascriptDebugWorkerMain.js'),
+  false,
+)
+
+await bundleJs(
+  join(node, 'src', 'nodeProcess.js'),
+  join(root, 'dist', 'dist', 'nodeProcess.js'),
   false,
 )
 

--- a/scripts/build.test.js
+++ b/scripts/build.test.js
@@ -1,8 +1,13 @@
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import test from 'node:test'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+  NodeForkedProcessRpcParent,
+  WebSocketRpcParent,
+} from '@lvce-editor/rpc'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -26,4 +31,72 @@ test('packages a listening debug worker', async () => {
   assert.match(worker, /Debug\.getStatus/)
   assert.match(worker, /globalThis\.rpc/)
   assert.doesNotMatch(worker, /from ['"]@lvce-editor\/rpc['"]/)
+})
+
+test('starts the packaged node process and invokes a debug command', async () => {
+  await import('./build.js')
+
+  const server = createServer((request, response) => {
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify({ value: 'debug-process-ok' }))
+  })
+  const sockets = new Set()
+  let controlRpc
+  let rpc
+  try {
+    const processPath = join(root, 'dist', 'dist', 'nodeProcess.js')
+    const childRpc = await NodeForkedProcessRpcParent.create({
+      commandMap: {},
+      path: processPath,
+    })
+    controlRpc = childRpc
+    const { promise: attached, reject, resolve } = Promise.withResolvers()
+    server.on('upgrade', (request, socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      socket.pause()
+      const serializableRequest = {
+        headers: request.headers,
+        method: request.method,
+        url: request.url,
+      }
+      const attach = async () => {
+        try {
+          await childRpc.invokeAndTransfer(
+            'NodeRpcProcess.handleWebSocket',
+            socket,
+            serializableRequest,
+          )
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      }
+      void attach()
+    })
+    await new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    assert.ok(address && typeof address === 'object')
+    const webSocket = new WebSocket(`ws://127.0.0.1:${address.port}`)
+    rpc = await WebSocketRpcParent.create({ commandMap: {}, webSocket })
+    await attached
+
+    const result = await rpc.invoke(
+      'Ajax.getJson',
+      `http://127.0.0.1:${address.port}/fixture`,
+    )
+
+    assert.deepEqual(result, { value: 'debug-process-ok' })
+  } finally {
+    await rpc?.dispose()
+    await controlRpc?.dispose()
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    server.closeAllConnections()
+    await new Promise((resolve) => server.close(resolve))
+  }
 })


### PR DESCRIPTION
## Summary\n\n- migrate the Debug Node RPC declaration from node to node-process\n- replace the legacy command-map entrypoint with a dedicated packaged process bootstrap\n- retain the separately importable debug command map\n- verify a packaged process can fetch JSON through a real fork and WebSocket\n\n## Validation\n\n- npm run lint\n- npm run type-check\n- npm test