### PR TITLE
fix: update rpc for websocket cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@lvce-editor/eslint-config": "^18.4.0",
         "@lvce-editor/package-extension": "^3.2.0",
-        "@lvce-editor/rpc": "^6.19.1",
+        "@lvce-editor/rpc": "^6.19.2",
         "@lvce-editor/server": "0.103.19",
         "@lvce-editor/shared-process": "^0.103.19",
         "@types/node": "^25.0.9",
@@ -3315,9 +3315,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.19.1.tgz",
-      "integrity": "sha512-3DwH6ofT2/pBEY28QjdoaALf8MylKrHDxA2hUSx5+OCHurZUhBYiBKLbvI8fx1VXaCkWElzf5g6qBGgwHWDSVA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.19.2.tgz",
+      "integrity": "sha512-ad1UxVe3VilkhqRAQHbTyAVjoD9gLShFQXaizpfabEPYTqL72XHjAjSumXDiPSThuO+VOR1TU8wDDN4wszpGEA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -17854,7 +17854,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@lvce-editor/rpc": "^6.19.1"
+        "@lvce-editor/rpc": "^6.19.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@lvce-editor/eslint-config": "^18.4.0",
     "@lvce-editor/package-extension": "^3.2.0",
-    "@lvce-editor/rpc": "^6.19.1",
+    "@lvce-editor/rpc": "^6.19.2",
     "@lvce-editor/server": "0.103.19",
     "@lvce-editor/shared-process": "^0.103.19",
     "@types/node": "^25.0.9",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -14,6 +14,6 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "@lvce-editor/rpc": "^6.19.1"
+    "@lvce-editor/rpc": "^6.19.2"
   }
 }


### PR DESCRIPTION
## Summary

- update @lvce-editor/rpc to 6.19.2
- rebuild self-hosted Node process entrypoints with remote WebSocket cleanup

## Validation

- unit tests pass
- packaged process test passes
- build/type/lint checks pass where defined

This propagates the remote transport cleanup fix found during official LVCE v0.108.0 server acceptance.